### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,79 +1,71 @@
-# Deezar
+# Epico
 
-Deezar est une application de streaming musical qui permet de rechercher, télécharger et gérer de la musique.
+Epico is a TypeScript based music streaming app that relies on the Deezer API.
+It lets you search for tracks, download them and manage your music library.
 
-## Fonctionnalités
+## Key features
+- Search and download songs from Deezer
+- User management with authentication
+- Automatic BPM analysis
+- Email notifications
+- Listening history and recommendations
 
-- Rechercher et télécharger de la musique via l'API de Deezer.
-- Gestion des comptes utilisateurs et authentification.
-- Envoi de notifications par e-mail.
-- Analyse automatique du BPM des morceaux.
-- Historique d'écoute et recommandations personnalisées.
-
-## Installation
-
-1. Clonez le dépôt :
-    ```sh
-    git clone https://github.com/MyEcoria/deezer_scrap.git
-    cd deezer_scrap
-    ```
-
-2. Installez les dépendances :
-    ```sh
-    npm install
-    ```
-
-3. Configurez l'application :
-   - Renommez le fichier `.env.exemple` en `.env` et modifiez les variables d'environnement selon vos besoins.
-
-4. Compilez le projet :
-    ```sh
-    npm run build
-    ```
-
-5. Démarrez l'application :
-    ```sh
-    npm start
-    ```
-
-6. Pour empaqueter l'application (Linux, macOS, Windows) :
-    ```sh
-    npm run pkg
-    ```
-
-## Utilisation
-
-### Endpoints API
-
-- **Inscription utilisateur** : `POST /user/register`
-- **Connexion utilisateur** : `POST /user/login`
-- **Confirmation d'inscription** : `GET /user/confirm/:id`
-- **Recherche de musique** : `POST /music/search`
-- **Lecture de musique** : `GET /music/:id.mp3`
-
-## Configuration
-
-- **Base de données** : Configurez la connexion dans le fichier `.env`.
-- **SMTP** : Paramétrez l'envoi des e-mails via les variables d'environnement.
-- **Stockage S3** : Configurez les paramètres S3 dans le fichier `.env`.
-
-## Structure du projet
-
-- Le code source se trouve dans le dossier `src` et les fonctions utilitaires dans le dossier `modules`.
-- Les définitions de types TypeScript se trouvent dans le dossier `types`.
-
-## Journal des modifications
-
-Documentez ici les évolutions et mises à jour du projet.
-
-## Auteur
-
-## Utilisation avec Docker
-
-1. Construisez et lancez tous les services :
+## Quick start
+1. Clone the repository
    ```sh
-   docker-compose up --build
+   git clone https://github.com/MyEcoria/epico.git
+   cd epico
+   ```
+2. Install dependencies
+   ```sh
+   npm install
+   ```
+3. Copy `.env.exemple` to `.env` and edit the values
+4. Build the project
+   ```sh
+   npm run build
+   ```
+5. Start the server
+   ```sh
+   npm start
+   ```
+6. Produce executables for Linux, macOS and Windows
+   ```sh
+   npm run pkg:all
    ```
 
-L'application sera disponible sur `http://localhost:8000`.
-La base de données est initialisée automatiquement à partir du fichier `schema.sql` lors du premier démarrage des conteneurs.
+## Running the worker
+The `worker/` directory contains a Bull-based service that processes downloads
+and track analysis in the background. Run it with:
+```sh
+npm --prefix worker install
+npm --prefix worker start
+```
+You can also build the worker using:
+```sh
+npm --prefix worker run build
+```
+
+## API usage
+- **POST /user/register** – register a user
+- **POST /user/login** – log in
+- **GET /user/confirm/:id** – confirm registration
+- **POST /music/search** – search for a track
+- **GET /music/:id.mp3** – stream a track
+
+## Configuration
+- **Database** – set your connection variables in `.env`
+- **SMTP** – configure email settings in `.env`
+- **S3 storage** – add your S3 credentials to `.env`
+
+## Project layout
+- Main source code in `src/` with utilities in `modules/`
+- Type definitions in `types/`
+- Background worker in `worker/`
+
+## Docker
+```sh
+docker-compose up --build
+```
+The application will be available on `http://localhost:8000` and the database
+will be created from `schema.sql` on first start.


### PR DESCRIPTION
## Summary
- rewrite README entirely in English
- keep the project name Epico and clarify install steps
- explain how to run and build the worker

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851b4617b188325bedbafaa58b93642